### PR TITLE
Fix copy constructors

### DIFF
--- a/neither/include/either.hpp
+++ b/neither/include/either.hpp
@@ -55,9 +55,9 @@ struct Either {
   constexpr Either( Either<L, R> const& e )
     : isLeft(e.isLeft) {
     if(isLeft) {
-      leftValue = e.leftValue;
+      new (&leftValue)L(e.leftValue);
     } else {
-      rightValue = e.rightValue;
+      new (&rightValue)R(e.rightValue);
     }
   }
 

--- a/neither/include/maybe.hpp
+++ b/neither/include/maybe.hpp
@@ -22,7 +22,7 @@ template <class T> struct Maybe {
 
   constexpr Maybe(Maybe<T> const &o) : hasValue{o.hasValue} {
     if (o.hasValue) {
-      value = o.value;
+      new (&value)T(o.value);
     }
   }
 


### PR DESCRIPTION
The copy constructors for `neither::Either` and `neither::Maybe` have been updated to use proper copy-construction using a placement new. 

Note: These values won't need to be deleted manually, but they will probably need to be manually destroyed, which the library already does.