### PR TITLE
Feature: Add Maybe#size() and Maybe#empty() compatible with STL containers  

### DIFF
--- a/neither/include/maybe.hpp
+++ b/neither/include/maybe.hpp
@@ -52,6 +52,8 @@ template <class T> struct Maybe {
 
   constexpr size_type size() const noexcept { return hasValue ? 1: 0; }
   
+  constexpr bool empty() const noexcept { return !hasValue; }
+  
   template<class F>
     constexpr auto map(F const &f) const&
     -> Maybe<decltype(f(isCopyable(value)))> {

--- a/neither/include/maybe.hpp
+++ b/neither/include/maybe.hpp
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <cassert>
+#include <cstddef>
 #include <neither/traits.hpp>
 
 namespace neither {
@@ -12,6 +13,8 @@ template <class T> struct Maybe;
 template <> struct Maybe<void> {};
 
 template <class T> struct Maybe {
+
+  using size_type = std::size_t;
 
   union {
     T value;
@@ -47,6 +50,8 @@ template <class T> struct Maybe {
     return value;
   }
 
+  constexpr size_type size() const noexcept { return hasValue ? 1: 0; }
+  
   template<class F>
     constexpr auto map(F const &f) const&
     -> Maybe<decltype(f(isCopyable(value)))> {

--- a/neither/include/maybe.hpp
+++ b/neither/include/maybe.hpp
@@ -17,14 +17,14 @@ template <class T> struct Maybe {
     T value;
   };
 
-  bool const hasValue = 0;
+  bool const hasValue;
 
-  constexpr Maybe() : hasValue{0} {}
+  constexpr Maybe() : hasValue{false} {}
 
-  constexpr Maybe(T const& value) :  value{value}, hasValue{1} {}
-  constexpr Maybe(T&& value) :  value{std::move(value)}, hasValue{1} {}
+  constexpr Maybe(T const& value) :  value{value}, hasValue{true} {}
+  constexpr Maybe(T&& value) :  value{std::move(value)}, hasValue{true} {}
 
-  constexpr Maybe(Maybe<void>) : hasValue{0} {}
+  constexpr Maybe(Maybe<void>) : hasValue{false} {}
 
   constexpr Maybe(Maybe<T> const &o) : hasValue{o.hasValue} {
     if (o.hasValue) {

--- a/neither/tests/maybe.cpp
+++ b/neither/tests/maybe.cpp
@@ -62,3 +62,12 @@ TEST(neither, maybe_size) {
   EXPECT_EQ(none.size(), 0);
   EXPECT_EQ(some.size(), 1);
 }
+
+TEST(neither, maybe_empty) {
+  
+  auto none = maybe<int>();
+  auto some = maybe<int>(1);
+
+  EXPECT_TRUE(none.empty());
+  EXPECT_FALSE(some.empty());
+}

--- a/neither/tests/maybe.cpp
+++ b/neither/tests/maybe.cpp
@@ -53,3 +53,12 @@ TEST(neither, maybe_comparison) {
   EXPECT_TRUE(d == d);
   EXPECT_TRUE(d == e);
 }
+
+TEST(neither, maybe_size) {
+  
+  auto none = maybe<int>();
+  auto some = maybe<int>(1);
+
+  EXPECT_EQ(none.size(), 0);
+  EXPECT_EQ(some.size(), 1);
+}


### PR DESCRIPTION
The goal is to make maybe more compatible with STL containers.

Two useful member functions are:

- size 
- empty

The second can also lead us to make hasValue a private member value in the future, but it could break existing client code..

Another small change is to treat hasValue with true/false, instead of 1/0, so it can more clearly expresses the intention of the code.