### PR TITLE
Silence 'defined but not used' warning

### DIFF
--- a/neither/include/maybe.hpp
+++ b/neither/include/maybe.hpp
@@ -109,6 +109,7 @@ auto maybe() -> Maybe<T> { return {}; }
 
 namespace {
 
+  inline
   bool equal(Maybe<void> const&, Maybe<void> const&) {
     return true;
   }


### PR DESCRIPTION
Compilation of maybe.hpp with g++ 7.3 results in the following warning being
emitted (here with `-Werror` enabled):

neither/maybe.hpp:112:8: error: ‘bool neither::{anonymous}::equal(const neither::Maybe<void>&, const neither::Maybe<void>&)’ defined but not used [-Werror=unused-function]
   bool equal(Maybe<void> const&, Maybe<void> const&) {