### PR TITLE
Remove copy construction from argument to std::move in rightMap &&

### DIFF
--- a/neither/include/either.hpp
+++ b/neither/include/either.hpp
@@ -182,7 +182,7 @@ struct Either {
   }
 
   template<class F, class L2=L, class R2=R>
-  auto rightMap(F const& rightCase)&& -> Either<L2, decltype(rightCase(std::move((R2)rightValue)))> {
+  auto rightMap(F const& rightCase)&& -> Either<L2, decltype(rightCase(std::move(rightValue)))> {
     using NextEither = Either<L, decltype(rightCase(std::move(rightValue)))>;
     return isLeft ?
       NextEither::leftOf( std::move(leftValue) ) :

--- a/neither/tests/either.cpp
+++ b/neither/tests/either.cpp
@@ -97,7 +97,7 @@ TEST(neither, either_flatMapToUnique) {
 }
 
 
-TEST(neither, either_mapToUnique) {
+TEST(neither, either_leftMapToUnique) {
   neither::Either<int, int> e = left(1);
 
   auto u = e.leftFlatMap([](auto x) { return
@@ -107,6 +107,23 @@ TEST(neither, either_mapToUnique) {
     return std::move(x);
   }).rightFlatMap([](auto&& x) {
     return Either<std::unique_ptr<int>, std::unique_ptr<int>>::rightOf(
+      std::make_unique<int>(2));
+  }).join();
+
+  ASSERT_TRUE(*u == 1);
+}
+
+
+TEST(neither, either_rightMapToUnique) {
+  neither::Either<int, int> e = right(1);
+
+  auto u = e.rightFlatMap([](auto x) { return
+    Either<int, std::unique_ptr<int>>::rightOf(
+      std::make_unique<int>(x));
+  }).rightMap([](auto&& x) {
+    return std::move(x);
+  }).leftFlatMap([](auto&& x) {
+    return Either<std::unique_ptr<int>, std::unique_ptr<int>>::leftOf(
       std::make_unique<int>(2));
   }).join();
 


### PR DESCRIPTION
When `rightMap` is applied to `Either` containing non-copyable type instance,
such as `std::unique_ptr<T>`, then the compiler will hard fail trying to
deduce types (`rightMap &&` should be picked) because there is `(R2)` cast
applied to `std::move` argument, thus forcing copy construction.

`leftMap` works because it does not have such cast.