### PR TITLE
Support for non-copyable objects in lvalues

### DIFF
--- a/neither/include/either.hpp
+++ b/neither/include/either.hpp
@@ -166,6 +166,14 @@ struct Either {
     return isLeft ? leftCase( leftValue ) : rightCase( rightValue );
   }
 
+  template<class LeftF, class RightF,
+    typename std::enable_if<!(sizeof(LeftF), std::is_copy_constructible<L>::value && std::is_copy_constructible<R>::value), int>::type = 0
+  >
+  constexpr auto join(LeftF const& leftCase, RightF const&  rightCase)&
+    -> decltype( isLeft? leftCase(std::move(leftValue)) : rightCase(std::move(rightValue)) ){
+    return isLeft ? leftCase(std::move(leftValue)) : rightCase(std::move(rightValue));
+  }
+
   template<class F, class L2=L, class R2=R>
   constexpr auto leftMap(F const& leftCase) const&
   -> Either<decltype(leftCase( isCopyable((L2)leftValue, (R2)rightValue) )), R2> {

--- a/neither/tests/either.cpp
+++ b/neither/tests/either.cpp
@@ -133,22 +133,22 @@ TEST(neither, either_rightMapToUnique) {
 
 TEST(neither, either_leftMapFromStoredUnique)
 {
-  neither::Either<std::unique_ptr<int>, std::unique_ptr<int>> e = left(std::make_unique<int>(1));
+  PtrOrPtr e = left(std::make_unique<int>(1));
   auto u = e.leftMap([](auto x){
     return(std::move(x));
   }).join();
 
-  ASSERT_TRUE(*u == 1);
+  ASSERT_EQ(*u, 1);
 }
 
 TEST(neither, either_rightMapFromStoredUnique)
 {
-  neither::Either<std::unique_ptr<int>, std::unique_ptr<int>> e = right(std::make_unique<int>(1));
+  PtrOrPtr e = right(std::make_unique<int>(1));
   auto u = e.rightMap([](auto x){
     return(std::move(x));
   }).join();
 
-  ASSERT_TRUE(*u == 1);
+  ASSERT_EQ(*u, 1);
 }
 
 TEST(neither, either_leftMapOfConst)
@@ -212,7 +212,7 @@ TEST(neither, either_leftFlatMapFromStoredUnique)
     return PtrOrPtr::leftOf(std::make_unique<int>(0));
   }).join();
 
-  ASSERT_TRUE(*u == 0);
+  ASSERT_EQ(*u, 0);
 }
 
 TEST(neither, either_rightFlatMapFromStoredUnique)
@@ -222,7 +222,7 @@ TEST(neither, either_rightFlatMapFromStoredUnique)
     return PtrOrPtr::leftOf(std::make_unique<int>(0));
   }).join();
 
-  ASSERT_TRUE(*u == 0);
+  ASSERT_EQ(*u, 0);
 }
 
 TEST(neither, either_joinFromStoredUnique)

--- a/neither/tests/either.cpp
+++ b/neither/tests/either.cpp
@@ -12,6 +12,7 @@ using namespace std::literals::string_literals;
 using IntOrStr = Either<int, std::string>;
 using StrOrInt = Either<std::string, int>;
 using StrOrStr = Either<std::string, std::string>;
+using PtrOrPtr = neither::Either<std::unique_ptr<int>, std::unique_ptr<int>>;
 
 TEST(neither, either_join_left) {
 
@@ -128,4 +129,121 @@ TEST(neither, either_rightMapToUnique) {
   }).join();
 
   ASSERT_TRUE(*u == 1);
+}
+
+TEST(neither, either_leftMapFromStoredUnique)
+{
+  neither::Either<std::unique_ptr<int>, std::unique_ptr<int>> e = left(std::make_unique<int>(1));
+  auto u = e.leftMap([](auto x){
+    return(std::move(x));
+  }).join();
+
+  ASSERT_TRUE(*u == 1);
+}
+
+TEST(neither, either_rightMapFromStoredUnique)
+{
+  neither::Either<std::unique_ptr<int>, std::unique_ptr<int>> e = right(std::make_unique<int>(1));
+  auto u = e.rightMap([](auto x){
+    return(std::move(x));
+  }).join();
+
+  ASSERT_TRUE(*u == 1);
+}
+
+TEST(neither, either_leftMapOfConst)
+{
+  const auto e = IntOrStr::leftOf(1);
+  const auto f = e.leftMap([](auto x){return x;});
+  const auto ret = f.rightMap([](auto x){return 0;}).join();
+
+  ASSERT_EQ(ret, 1);
+}
+
+TEST(neither, either_rightMapOfConst)
+{
+  const auto e = IntOrStr::rightOf("Hello World!");
+  const auto f = e.leftMap([](auto x){return std::string("Bye World!");});
+  const auto ret = f.rightMap([](auto x){return x;}).join();
+
+  ASSERT_EQ(ret, "Hello World!");
+}
+
+TEST(neither, either_leftMapNotAltered)
+{
+  auto e = IntOrStr::leftOf(1);
+  e.leftMap([](auto x){return 3;});
+  const auto ret = e.rightMap([](auto right){return 0;}).join();
+
+  ASSERT_EQ(ret, 1);
+}
+
+TEST(neither, either_leftMapOfConstNotAltered)
+{
+  const auto e = IntOrStr::leftOf(1);
+  e.leftMap([](auto x){return 3;});
+  const auto ret = e.rightMap([](auto right){return 0;}).join();
+
+  ASSERT_EQ(ret, 1);
+}
+
+TEST(neither, either_rightMapNotAltered)
+{
+  auto e = IntOrStr::rightOf("Hello World!");
+  e.leftMap([](auto left){return "";});
+  const auto ret = e.leftMap([](auto x){return std::string("Bye World!");}).join();
+
+  ASSERT_EQ(ret, "Hello World!");
+}
+
+TEST(neither, either_rightMapOfConstNotAltered)
+{
+  const auto e = IntOrStr::rightOf("Hello World!");
+  e.leftMap([](auto left){return "";});
+  const auto ret = e.leftMap([](auto x){return std::string("Bye World!");}).join();
+
+  ASSERT_EQ(ret, "Hello World!");
+}
+
+TEST(neither, either_leftFlatMapFromStoredUnique)
+{
+  PtrOrPtr e = left(std::make_unique<int>(1));
+  auto u = e.leftFlatMap([](auto x){
+    return PtrOrPtr::leftOf(std::make_unique<int>(0));
+  }).join();
+
+  ASSERT_TRUE(*u == 0);
+}
+
+TEST(neither, either_rightFlatMapFromStoredUnique)
+{
+  PtrOrPtr e = right(std::make_unique<int>(1));
+  auto u = e.rightFlatMap([](auto x){
+    return PtrOrPtr::leftOf(std::make_unique<int>(0));
+  }).join();
+
+  ASSERT_TRUE(*u == 0);
+}
+/*
+TEST(neither, either_joinFromStoredUnique)
+{
+  PtrOrPtr e = right(std::make_unique<int>(1));
+  auto u = e.join(
+    [](auto left){
+      return(std::move(left));
+    },
+    [](auto right){
+      return(std::move(right));
+    }
+  );
+
+  ASSERT_EQ(*u, 1);
+}*/
+
+TEST(neither, either_joinFromStoredUniqueNoFunction)
+{
+  PtrOrPtr e = right(std::make_unique<int>(1));
+  auto u = e.join();
+
+  ASSERT_EQ(*u, 1);
 }

--- a/neither/tests/either.cpp
+++ b/neither/tests/either.cpp
@@ -224,21 +224,21 @@ TEST(neither, either_rightFlatMapFromStoredUnique)
 
   ASSERT_TRUE(*u == 0);
 }
-/*
+
 TEST(neither, either_joinFromStoredUnique)
 {
   PtrOrPtr e = right(std::make_unique<int>(1));
   auto u = e.join(
     [](auto left){
-      return(std::move(left));
+      return left;
     },
     [](auto right){
-      return(std::move(right));
+      return right;
     }
   );
 
   ASSERT_EQ(*u, 1);
-}*/
+}
 
 TEST(neither, either_joinFromStoredUniqueNoFunction)
 {


### PR DESCRIPTION
!READ DESCRIPTION FIRST! Not up to merge yet.

If you would be willing to adopt these changes I will also adjust `neither::Maybe` (and `neither::lift` if needed). Please give feedback if this matches your design concept. Unfortunately I did not find a contribution policy in the repository. :(

_Contents_
This relaxes the restrictions on using the library with types that are not copy-constructible. It leverages the SFINAE idiom to provide proper implementation for types like `std::unique_ptr`s. This should not change behavior of existing code, as the template candidates only apply to cases, where previously compilation would not be possible.

_Changes_
- Extend neither::Either with template candidates for non-copyable types.
- Provide additional tests for the Either class regarding use of non-copyable types.